### PR TITLE
Relax the gemspec to work with Rails 7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     lookbook (0.2.1)
       listen (~> 3.3)
-      rails (~> 6.0)
+      rails (>= 6.0)
       redcarpet (~> 3.5)
       rouge (~> 3.26)
       view_component (~> 2.0)
@@ -212,4 +212,4 @@ DEPENDENCIES
   warning (~> 1.2)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/lookbook.gemspec
+++ b/lookbook.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,lib,public}/**/*", "LICENSE.txt", "README.md"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails", "~> 6.0"
+  spec.add_dependency "rails", ">= 6.0"
   spec.add_dependency "view_component", "~> 2.0"
   spec.add_dependency "redcarpet", "~> 3.5"
   spec.add_dependency "rouge", "~> 3.26"


### PR DESCRIPTION
Without this, Lookbook fails to allow the app to bundle when running Rails from github and soon to be released the 7.0 alpha gems.

We dual-boot our rails application at work with two versions of Rails (Latest released 6.1 and then main from GitHub) and ever since the dependency was locked to ~> 6.0 this has prevented us from bundling.

I don't think there's anything specific in Lookbook that would break from Rails 7 but we'll certainly keep our eye out.