### PR TITLE
Enable previews to work with ViewComponentContrib

### DIFF
--- a/lib/lookbook/parser.rb
+++ b/lib/lookbook/parser.rb
@@ -5,7 +5,7 @@ module Lookbook
     YARDOC_FILE_PATH = Rails.root.join("tmp/storage/.yardoc").to_s
 
     def initialize(paths)
-      @paths = paths.map { |p| "#{p}/**/*_preview.rb" }
+      @paths = paths.map { |p| "#{p}/**/*preview.rb" }
       YARD::Registry.yardoc_file = YARDOC_FILE_PATH
     end
 


### PR DESCRIPTION
ViewComponentContrib allows for component_name/preview.rb file structure. Changing the glob allows for lookbook to work, as long as the preview does not inherit from ViewComponentContrib::Preview (due to conflicting Preview templates and who does the rendering).