### PR TITLE
Stop rendering `srcdoc` preview when it is disabled

### DIFF
--- a/app/controllers/lookbook/app_controller.rb
+++ b/app/controllers/lookbook/app_controller.rb
@@ -27,7 +27,9 @@ module Lookbook
         begin
           set_params
           @examples = examples_data
-          @preview_srcdoc = render_examples(examples_data).gsub("\"", "&quot;")
+          @preview_srcdoc = if lookbook.preview_srcdoc
+            render_examples(examples_data).gsub("\"", "&quot;")
+          end
           @panels = panels.filter { |name, panel| panel[:show] }
         rescue *EXCEPTIONS
           render "error"


### PR DESCRIPTION
As [mentioned in documentation](https://github.com/allmarkedup/lookbook#blank-preview-window) and handled in configuration, setting `config.preview_srcdoc` should disable `srcdoc` content generation.

The controller did not take into account this flag and always rendered it and made it accessible by the view.

This PR fixes this behavior.

I'm willing to also check in the view if `@preview_srcdoc` is blank to skip outputting `srcdoc=""` altogether.