### PR TITLE
Better visualization for preview named Preview 

### DIFF
--- a/lib/lookbook/preview.rb
+++ b/lib/lookbook/preview.rb
@@ -44,7 +44,7 @@ module Lookbook
     # Examples::FooBarComponentPreview -> "Examples::FooBar"
     # Examples::FooBarComponent::Preview -> "Examples::FooBar"
     def lookbook_name
-      name.chomp("ComponentPreview").chomp("Component::Preview").chomp("::")
+      name.chomp("ComponentPreview").chomp("Component::Preview").chomp("::Preview").chomp("::")
     end
 
     # Examples::FooBarComponentPreview -> "examples/foo_bar"


### PR DESCRIPTION
Hi, first of all congratutations. This is a truly gem  :nerd_face: 


I tend to prefer the convention as per https://github.com/palkan/view_component-contrib where components are named Component , previews are named Preview and we put everything on the same folder. This small commit helps with the visualization of such convention, otherwise I get a list of folders named preview on my nav. 

Thanks and regards 

Murilo 
