### PR TITLE
Fix not scrollable overflowing long params list

### DIFF
--- a/app/views/lookbook/previews/panels/_params.html.erb
+++ b/app/views/lookbook/previews/panels/_params.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-gray-50 h-full">
+<div class="bg-gray-50 h-full overflow-auto">
   <% if @example.type == :group %>
     <div class="p-4 prose prose-sm">
       <em class='opacity-50'>Params are not yet supported for grouped examples.</em>


### PR DESCRIPTION
Fix for when the list of parameters in the drawer is too long and overflowing and the panel is not scrollable.