### PR TITLE
Manually prefix route helper in application helper

### DIFF
--- a/app/helpers/lookbook/application_helper.rb
+++ b/app/helpers/lookbook/application_helper.rb
@@ -11,7 +11,7 @@ module Lookbook
     def landing_path
       landing = feature_enabled?(:pages) ? Lookbook.pages.find(&:landing) || Lookbook.pages.first : nil
       if landing.present?
-        page_path(landing.lookup_path)
+        lookbook_page_path landing.lookup_path
       else
         lookbook_home_path
       end


### PR DESCRIPTION
Thanks for the very snazzy view component preview set up. We're really loving it at The Lookout Way.

It looks like this was done in many other places in
c8cf162dd41f42e5d405503764dc007a7a7c97d5.

I'm not _sure_ but I think the difference between our app and the dummy
and demo apps is that we set:

    config.action_controller.include_all_helpers = false

Therefore PageHelper isn't automatically loaded for the
PagesController. The ApplicationHelper is manually included in
ApplicationController, but the PageHelper isn't manually included in the
PagesController, where page_path is being called by the landing_path
method, which is being called when rending the branding partial, which
happens as part of PagesController#show.

This diff seems to get our pages rendering again, without it we get a `NoMethodError in Lookbook::Pages#show`.

```
undefined method `page_path' for #<ActionView::Base:0x00000000090088>
Did you mean?  image_path

lookbook (0.9.0) app/helpers/lookbook/application_helper.rb:14:in `landing_path'
lookbook (0.9.0) app/views/lookbook/components/_branding.html.erb:3
```

Thanks again for the great engine :). Let me know if you'd like to go about this in a different way or if there's more I can do.