### PR TITLE
fix: Escape quotes in params values

### DIFF
--- a/app/views/lookbook/previews/inputs/_select.html.erb
+++ b/app/views/lookbook/previews/inputs/_select.html.erb
@@ -2,6 +2,6 @@
   name="<%= name %>"
   class="form-input"
   x-model="value"
-  x-data="param('<%= name %>', '<%= value %>')">
+  x-data="param('<%= name %>', '<%= j(value) %>')">
   <%= options_for_select(options, value) %>
 </select>

--- a/app/views/lookbook/previews/inputs/_text.html.erb
+++ b/app/views/lookbook/previews/inputs/_text.html.erb
@@ -3,6 +3,6 @@
   type="<%= input_type %>"
   name="<%= name %>"
   value="<%= value %>"
-  x-data="param('<%= name %>', '<%= value %>', {debounce: 300})"
+  x-data="param('<%= name %>', '<%= j(value) %>', {debounce: 300})"
   x-model="value"
   @keyup.stop>

--- a/app/views/lookbook/previews/inputs/_textarea.html.erb
+++ b/app/views/lookbook/previews/inputs/_textarea.html.erb
@@ -4,5 +4,5 @@
   rows="4"
   @keyup.stop
   x-model="value"
-  x-data="param('<%= name %>', '<%= value %>', {debounce: 300})"
+  x-data="param('<%= name %>', '<%= j(value) %>', {debounce: 300})"
 ><%= value %></textarea>

--- a/app/views/lookbook/previews/inputs/_toggle.html.erb
+++ b/app/views/lookbook/previews/inputs/_toggle.html.erb
@@ -1,4 +1,4 @@
-<div x-data="param('<%= name %>', <%= value %>)" data-morph-strategy="replace">
+<div x-data="param('<%= name %>', <%= j(value) %>)" data-morph-strategy="replace">
   <button type="button"
     class="relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-400"
     :class="{'bg-indigo-500': value, 'bg-gray-300': !value}"

--- a/test/app_integration_test.rb
+++ b/test/app_integration_test.rb
@@ -124,7 +124,7 @@ module Lookbook
 
             should "render a text input" do
               within "#inspector-panel-#{@example.id}-params" do
-                assert page.has_field?("blurb", type: "text", with: "default text")
+                assert page.has_field?("blurb", type: "text", with: "default text and \"some\" 'quotes'")
               end
             end
           end
@@ -137,7 +137,7 @@ module Lookbook
 
             should "render a text input" do
               within "#inspector-panel-#{@example.id}-params" do
-                assert page.has_field?("blurb", type: "text", with: "default text")
+                assert page.has_field?("blurb", type: "text", with: "default text and \"some\" 'quotes'")
               end
             end
           end
@@ -150,7 +150,7 @@ module Lookbook
 
             should "render a textarea" do
               within "#inspector-panel-#{@example.id}-params" do
-                assert page.has_css?("textarea[name='blurb']", text: "default text")
+                assert page.has_css?("textarea[name='blurb']", text: "default text and \"some\" 'quotes'")
               end
             end
           end
@@ -163,7 +163,7 @@ module Lookbook
 
             should "render a select" do
               within "#inspector-panel-#{@example.id}-params" do
-                assert page.has_select?("blurb", with_selected: "option one", with_options: ["option one", "option two"])
+                assert page.has_select?("blurb", with_selected: "option 'one'", with_options: ["option 'one'", "option \"two\""])
               end
             end
           end

--- a/test/dummy/test/components/previews/param_component_preview.rb
+++ b/test/dummy/test/components/previews/param_component_preview.rb
@@ -1,22 +1,22 @@
 class ParamComponentPreview < ViewComponent::Preview
   
   # @param blurb
-  def default_input(blurb: "default text")
+  def default_input(blurb: "default text and \"some\" 'quotes'")
     render ParamComponent.new(blurb: blurb)
   end
 
   # @param blurb text
-  def text_input(blurb: "default text")
+  def text_input(blurb: "default text and \"some\" 'quotes'")
     render ParamComponent.new(blurb: blurb)
   end
 
   # @param blurb textarea
-  def textarea_input(blurb: "default text")
+  def textarea_input(blurb: "default text and \"some\" 'quotes'")
     render ParamComponent.new(blurb: blurb)
   end
 
-  # @param blurb select [option one, option two]
-  def select_input(blurb: "option one")
+  # @param blurb select [option 'one', option "two"]
+  def select_input(blurb: "option 'one'")
     render ParamComponent.new(blurb: blurb)
   end
 


### PR DESCRIPTION
Hi! Thanks for the awesome gem. There was a minor bug that prevented using params with quotes, e.g.:

```ruby
  # @param message text
  def example(message: "Let's go!")
    # render component
  end
```

![image](https://user-images.githubusercontent.com/6882605/176664467-bb701162-99fe-484f-ae0b-59f490b54501.png)