### PR TITLE
Replaced max-w-3xl with max-w-screen-lg

### DIFF
--- a/app/views/lookbook/pages/show.html.erb
+++ b/app/views/lookbook/pages/show.html.erb
@@ -1,5 +1,5 @@
 <div class="px-4 md:px-10 pt-8 md:pt-10 overflow-auto scroll-smooth w-full max-h-full pb-12" x-ref="scroller">
-  <div class="w-full max-w-3xl mx-auto h-full flex flex-col">
+  <div class="w-full max-w-screen-lg mx-auto h-full flex flex-col">
     <% if @page.header? %>
       <header id="page-header" class="mb-8 prose max-w-none flex-none">
         <h1><%= @page.title %></h1>


### PR DESCRIPTION
I found that the width for docs content was too narrow. I added a different class name to make it wider:

<img width="1479" alt="Screen Shot 2022-07-18 at 2 12 42 PM" src="https://user-images.githubusercontent.com/1253321/179576246-8db77c8a-10c3-456e-a260-3ba5398d615b.png">
