### PR TITLE
Updating input params to accept date related inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,8 @@ The following **input field types** are available for use:
 
 ```ruby
 @param <name> text
+@param <name> date
+@param <name> datetime-local
 @param <name> email
 @param <name> number
 @param <name> url

--- a/lib/lookbook/params.rb
+++ b/lib/lookbook/params.rb
@@ -88,6 +88,8 @@ module Lookbook
 
       def input_text?(input)
         [
+          "date",
+          "datetime-local",
           "email",
           "number",
           "tel",

--- a/lib/lookbook/params.rb
+++ b/lib/lookbook/params.rb
@@ -52,6 +52,14 @@ module Lookbook
             result = []
           end
           result
+        when "datetime"
+          begin
+            result = DateTime.parse(value)
+          rescue Date::Error
+            Lookbook.logger.debug "Failed to parse '#{value}' into a DateTime"
+            result = DateTime.now
+          end
+          result
         else
           begin
             type_class = "ActiveModel::Type::#{type}".constantize
@@ -81,6 +89,8 @@ module Lookbook
           "Boolean"
         elsif default.is_a? Symbol
           "Symbol"
+        elsif ["date", "datetime-local"].include?(input&.downcase) || default.is_a? DateTime
+          "DateTime"
         else
           "String"
         end


### PR DESCRIPTION
This PR adds [date](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date) and [datetime-local](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local) as `@param` input options.

These are both types of `<input>` tags so didn't think it was necessary to add new erb files for the previews.