### PR TITLE
Use prefixed path helper

### DIFF
--- a/app/views/lookbook/pages/show.html.erb
+++ b/app/views/lookbook/pages/show.html.erb
@@ -8,7 +8,7 @@
     <div id="page-banner-<%= @page.id %>" class="flex items-center ml-auto pr-2">
       <% if @previous_page %>
         <a ref="header-previous-page"
-          href="<%= page_path @previous_page.lookup_path %>"
+          href="<%= lookbook_page_path @previous_page.lookup_path %>"
           x-tooltip.theme.lookbook="`Previous page`"
           class="flex-none p-1">
           <%= icon "chevron-left", size: 4, class: "hover:text-indigo-800" %>
@@ -21,7 +21,7 @@
 
       <% if @next_page %>
         <a ref="header-next-page"
-          href="<%= page_path @next_page.lookup_path %>"
+          href="<%= lookbook_page_path @next_page.lookup_path %>"
           x-tooltip.theme.lookbook="`Next page`"
           class="flex-none p-1">
             <%= icon "chevron-right", size: 4, class: "hover:text-indigo-800" %>
@@ -75,7 +75,7 @@
         <footer id="page-footer-<%= @page.id %>" class="flex items-center justify-between border-t border-gray-300 mt-12 pt-8">
           <% if @previous_page %>
             <a ref="footer-previous-page"
-              href="<%= page_path @previous_page.lookup_path %>"
+              href="<%= lookbook_page_path @previous_page.lookup_path %>"
               class="flex items-center flex-none">
               <%= icon "arrow-left", size: 4, class: "hover:text-indigo-800" %>
               <span class="ml-2 underline"><%= @previous_page.title %></span>
@@ -84,7 +84,7 @@
 
           <% if @next_page %>
             <a ref="footer-next-page"
-              href="<%= page_path @next_page.lookup_path %>"
+              href="<%= lookbook_page_path @next_page.lookup_path %>"
               class="flex items-center flex-none ml-auto">
               <span class="mr-2 underline"><%= @next_page.title %></span>
               <%= icon "arrow-right", size: 4, class: "hover:text-indigo-800" %>


### PR DESCRIPTION
Sorry, this is similar to the other PR we submitted! We were only
rendering one page so didn't run into this until now 😅

Hopefully this is the right move to keep the 'page_path' helper working
in page content while also supporting disabling the
`config.action_controller.include_all_helpers` Rails configuration
option.

Thanks again, we continue to love using Lookbook. It's been really ace 
linking directly to great looking component previews when talking about
new UIs :)