### PR TITLE
feat: Add support for figma as design reference

### DIFF
--- a/app/controllers/lookbook/previews_controller.rb
+++ b/app/controllers/lookbook/previews_controller.rb
@@ -67,6 +67,7 @@ module Lookbook
       render_args = @preview.render_args(example.name, params: preview_controller.params.permit!)
       has_template = render_args[:template] != "view_components/preview"
       {
+        design: example.design,
         label: example.label,
         notes: example.notes,
         html: preview_controller.process(:render_example_to_string, @preview, example.name),
@@ -127,6 +128,13 @@ module Lookbook
           show: true,
           disabled: false,
           copy: true
+        },
+        design: {
+          label: "Design",
+          template: "lookbook/previews/panels/design",
+          hotkey: "d",
+          show: true,
+          disabled: @examples.select { |e| e[:design].present? }.none?
         },
         notes: {
           label: "Notes",

--- a/app/views/lookbook/previews/panels/_design.html.erb
+++ b/app/views/lookbook/previews/panels/_design.html.erb
@@ -1,0 +1,32 @@
+<% items = examples.select { |example| example[:design].present? } %>
+
+<div class="text-gray-600 bg-gray-50 h-full overflow-auto" data-morph-strategy="replace">
+  <% if items.many? %>
+    <div class="divide-y divide-dashed divide-gray-300">
+      <% items.each do |item| %>
+        <% raise items %>
+        <div class="px-4 pt-3 pb-6 relative">
+          <h6 class="text-[11px] text-gray-500 italic inline-block uppercase tracking-wide mb-4">
+            <%= item[:label] %>
+          </h6>
+          <div class="prose prose-sm prose-a:text-indigo-900">
+            <% if items.first.key?(:figma) %>
+              <%= tag.iframe src: "https://www.figma.com/embed?embed_host=share&url=#{CGI.escape(item[:design][:figma])}", class: "w-screen h-screen" %>
+            <% end %>
+          </iframe>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="p-4 prose prose-sm prose-a:text-indigo-900">
+      <% if items.any? %>
+        <% if items.first[:design].key?(:figma) %>
+          <%= tag.iframe src: "https://www.figma.com/embed?embed_host=share&url=#{CGI.escape(items.first[:design][:figma])}", class: "w-screen h-screen" %>
+        <% end %>
+      <% else %>
+        <em class='opacity-50'>No design provided.</em>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/lib/lookbook/code_inspector.rb
+++ b/lib/lookbook/code_inspector.rb
@@ -21,6 +21,10 @@ module Lookbook
       end
     end
 
+    def design
+      extract_params_from_tag(:design)
+    end
+
     def label
       code_object&.tag(:label)&.text
     end
@@ -40,20 +44,7 @@ module Lookbook
     end
 
     def display_params
-      display_params = {}.with_indifferent_access
-      if code_object&.tags(:display).present?
-        code_object.tags(:display).each do |tag|
-          parts = tag.text.strip.match(/^([^\s]*)\s?(.*)$/)
-          if parts.present?
-            begin
-              display_params[parts[1]] = YAML.safe_load(parts[2] || "~")
-            rescue SyntaxError => err
-              Lookbook.logger.error("\n👀 [Lookbook] Invalid JSON in @display tag.\n👀 [Lookbook] (#{err})\n")
-            end
-          end
-        end
-      end
-      display_params
+      extract_params_from_tag(:display)
     end
 
     def parameter_defaults
@@ -68,6 +59,25 @@ module Lookbook
 
     def methods
       code_object&.meths
+    end
+
+    private
+
+    def extract_params_from_tag(tag)
+      params = {}.with_indifferent_access
+      if code_object&.tags(tag).present?
+        code_object.tags(tag).each do |tag|
+          parts = tag.text.strip.match(/^([^\s]*)\s?(.*)$/)
+          if parts.present?
+            begin
+              params[parts[1]] = YAML.safe_load(parts[2] || "~")
+            rescue SyntaxError => err
+              Lookbook.logger.error("\n👀 [Lookbook] Invalid JSON in @#{tag} tag.\n👀 [Lookbook] (#{err})\n")
+            end
+          end
+        end
+      end
+      params
     end
   end
 end

--- a/lib/lookbook/parser.rb
+++ b/lib/lookbook/parser.rb
@@ -26,6 +26,7 @@ module Lookbook
     class << self
       def define_tags
         YARD::Tags::Library.define_tag("Hidden status", :hidden)
+        YARD::Tags::Library.define_tag("Design", :design)
         YARD::Tags::Library.define_tag("Label", :label)
         YARD::Tags::Library.define_tag("Display", :display)
         YARD::Tags::Library.define_tag("Position", :position)

--- a/lib/lookbook/preview.rb
+++ b/lib/lookbook/preview.rb
@@ -3,7 +3,7 @@ module Lookbook
     include Utils
 
     delegate :name, :render_args, to: :@preview
-    delegate :position, :group, :notes, :hidden?, to: :@preview_inspector
+    delegate :position, :group, :design, :notes, :hidden?, to: :@preview_inspector
 
     def initialize(preview)
       @preview = preview
@@ -16,6 +16,10 @@ module Lookbook
 
     def preview_class
       @preview.name
+    end
+
+    def design
+      @preview_inspector&.design&.presence || lookup_path.split("/").last.titleize
     end
 
     def label

--- a/lib/lookbook/preview_example.rb
+++ b/lib/lookbook/preview_example.rb
@@ -3,7 +3,7 @@ module Lookbook
     include Utils
 
     attr_reader :name, :preview
-    delegate :params, :position, :group, :notes, :hidden?, :source, to: :@example_inspector
+    delegate :params, :position, :group, :design, :notes, :hidden?, :source, to: :@example_inspector
 
     def initialize(name, preview)
       @name = name


### PR DESCRIPTION
Hello! 

We are currently testing your project for our company. 
We needs Figma support as design reference, so we added it:

Usage:
```
@design figma [figma_url]
```

If you like it, we could add test to make it merged.

Thank you for all your work!