### PR TITLE
Disable CSP in development environment

### DIFF
--- a/app/controllers/lookbook/application_controller.rb
+++ b/app/controllers/lookbook/application_controller.rb
@@ -1,5 +1,6 @@
 module Lookbook
   class ApplicationController < ActionController::Base
+    content_security_policy false, if: -> { Rails.env.development? }
     protect_from_forgery with: :exception
 
     helper Lookbook::ApplicationHelper


### PR DESCRIPTION
Rails applications that use the their Content Security Policy also in the development environment are likely to block and break Lookbook. When that happens, all the user sees is a blank white page, and some errors in the browser console :eyes: 

This change disables any CSP in the Lookbook controllers, but only in development. Production environments are not impacted.