### PR TITLE
Add list of companies who use Lookbook to docs homepage

### DIFF
--- a/docs/src/guide/index.md
+++ b/docs/src/guide/index.md
@@ -50,6 +50,10 @@ If you want to have a quick play with Lookbook, the easiest way is to [give the 
 
 If you'd rather dig in a bit more and run the demo app locally, the [demo repo]({{ site.data.external.demo.repo }}) contains instructions on how to get it up and running.
 
+## Who uses Lookbook?
 
+* [Clio](https://www.clio.com/)
+
+Using Lookbook? [Send a pull request](https://github.com/allmarkedup/lookbook/edit/main/docs/src/guide/index.md) to update this list!
 
 {{ toc }}


### PR DESCRIPTION
## Summary

Adds a new section that lists the companies that are using Lookbook. I've copied the structure used by the [ViewComponents](https://viewcomponent.org/#who-uses-viewcomponent) project.

Closes https://github.com/allmarkedup/lookbook/issues/111

## Notes for reviewer

I work for [Clio](https://www.clio.com/) and can verify that we do indeed use and love Lookbook!

## Screenshot

![add_who_uses_lookbook](https://user-images.githubusercontent.com/788414/188726150-e5ea8eb4-11ba-4826-8693-cbbc54ff983f.png)

