### PR TITLE
fix: Conditionally call `content_security_policy`

### DIFF
--- a/app/controllers/lookbook/application_controller.rb
+++ b/app/controllers/lookbook/application_controller.rb
@@ -1,6 +1,9 @@
 module Lookbook
   class ApplicationController < ActionController::Base
-    content_security_policy false, if: -> { Rails.env.development? }
+    if respond_to?(:content_security_policy)
+      content_security_policy false, if: -> { Rails.env.development? }
+    end
+
     protect_from_forgery with: :exception
 
     helper Lookbook::ApplicationHelper


### PR DESCRIPTION
The `content_security_policy` method isn't available in Rails <= 5.1 so using lookbook >= 0.9.7 fails on older version of Rails. This PR checks that `content_security_policy` is available before trying to call it. This _should_ ensure compatibility with older versions of Rails 🤞 I'll open another PR or an issue if I find anything else.