### PR TITLE
Updating docs site for date and datetime-local input options

### DIFF
--- a/docs/src/guide/previews/params.md
+++ b/docs/src/guide/previews/params.md
@@ -77,6 +77,8 @@ Single line fields, useful for short strings of text or numbers.
 @param <name> number
 @param <name> url
 @param <name> tel
+@param <name> date
+@param <name> datetime-local
 ```
 
 {%= note :info do %}


### PR DESCRIPTION
Congrats on the 1.0 launch!

I noticed the docs site was missing the input options added in https://github.com/allmarkedup/lookbook/pull/116

I'm adding the param options here