### PR TITLE
Docs: Fix broken annotations link in quick start

### DIFF
--- a/docs/src/guide/quick-start.md
+++ b/docs/src/guide/quick-start.md
@@ -114,6 +114,6 @@ You can create as many example methods as you like in order to showcase all the 
 
 ## Dive deeper...
 
-Now that you have a component preview to experiment with you can dig into the [preview docs](/guide/previews) to learn more about adding [annotations](/guide/previews/annotations), using [preview layouts](/guide/previews/layouts), [grouping examples](/guide/previews/grouping) and more.
+Now that you have a component preview to experiment with you can dig into the [preview docs](/guide/previews) to learn more about adding [annotations](/guide/previews/annotating), using [preview layouts](/guide/previews/layouts), [grouping examples](/guide/previews/grouping) and more.
 
 {{ toc }}


### PR DESCRIPTION
Just a quick docs fix of the annotations link in quick-start.md (/guide/previews/annotating vice /guide/previews/annotations)