### PR TITLE
Add config option to disable action_view annotations

### DIFF
--- a/docs/src/_data/config_options.yml
+++ b/docs/src/_data/config_options.yml
@@ -168,7 +168,7 @@
 - name: preview_disable_action_view_annotations
   group: string
   type: Boolean
-  default: false
+  default: true
   example: "config.lookbook.preview_disable_action_view_annotations = true"
   description: "Turns off action view filename annotations when generating rendered component source."
 

--- a/docs/src/_data/config_options.yml
+++ b/docs/src/_data/config_options.yml
@@ -165,11 +165,11 @@
   example: config.lookbook.parser_registry_path = "path/to/temporary/storage"
   description: The directory to write the (temporary) parser registry file to.
 
-- name: disable_action_view_annotations
+- name: preview_disable_action_view_annotations
   group: string
   type: Boolean
   default: false
-  example: "config.lookbook.disable_action_view_annotations = true"
+  example: "config.lookbook.preview_disable_action_view_annotations = true"
   description: "Turns off action view filename annotations when generating rendered component source."
 
 - name: experimental_features

--- a/docs/src/_data/config_options.yml
+++ b/docs/src/_data/config_options.yml
@@ -165,6 +165,13 @@
   example: config.lookbook.parser_registry_path = "path/to/temporary/storage"
   description: The directory to write the (temporary) parser registry file to.
 
+- name: disable_action_view_annotations
+  group: string
+  type: Boolean
+  default: false
+  example: "config.lookbook.disable_action_view_annotations = true"
+  description: "Turns off action view filename annotations when generating rendered component source."
+
 - name: experimental_features
   group: system
   type: Boolean | Array

--- a/lib/lookbook/config.rb
+++ b/lib/lookbook/config.rb
@@ -24,6 +24,7 @@ module Lookbook
         preview_display_params: {},
         preview_srcdoc: nil,
         preview_tags: {},
+        preview_disable_action_view_annotations: true,
         sort_examples: false,
 
         listen: Rails.env.development?,
@@ -40,8 +41,6 @@ module Lookbook
         ui_theme: "indigo",
         ui_theme_overrides: {},
         ui_favicon: true,
-
-        preview_disable_action_view_annotations: false,
 
         hooks: {
           after_initialize: [],

--- a/lib/lookbook/config.rb
+++ b/lib/lookbook/config.rb
@@ -41,6 +41,8 @@ module Lookbook
         ui_theme_overrides: {},
         ui_favicon: true,
 
+        disable_action_view_annotations: false,
+
         hooks: {
           after_initialize: [],
           before_exit: [],

--- a/lib/lookbook/config.rb
+++ b/lib/lookbook/config.rb
@@ -41,7 +41,7 @@ module Lookbook
         ui_theme_overrides: {},
         ui_favicon: true,
 
-        disable_action_view_annotations: false,
+        preview_disable_action_view_annotations: false,
 
         hooks: {
           after_initialize: [],

--- a/lib/lookbook/preview_controller.rb
+++ b/lib/lookbook/preview_controller.rb
@@ -27,7 +27,7 @@ module Lookbook
     end
 
     def with_optional_annotations
-      if Lookbook.config.disable_action_view_annotations
+      if Lookbook.config.preview_disable_action_view_annotations
         original_value = ActionView::Base.annotate_rendered_view_with_filenames
         ActionView::Base.annotate_rendered_view_with_filenames = false
 

--- a/lib/lookbook/preview_controller.rb
+++ b/lib/lookbook/preview_controller.rb
@@ -11,7 +11,10 @@ module Lookbook
       opts = {}
       opts[:layout] = nil
       opts[:locals] = locals if locals.present?
-      render html: render_to_string(template, **opts)
+
+      with_optional_annotations do
+        render html: render_to_string(template, **opts)
+      end
     end
 
     def render_in_layout_to_string(template, locals, opts = {})
@@ -21,6 +24,21 @@ module Lookbook
         html += opts[:append_html]
       end
       render html: html
+    end
+
+    def with_optional_annotations
+      if Lookbook.config.disable_action_view_annotations
+        original_value = ActionView::Base.annotate_rendered_view_with_filenames
+        ActionView::Base.annotate_rendered_view_with_filenames = false
+
+        res = yield
+
+        ActionView::Base.annotate_rendered_view_with_filenames = original_value
+
+        res
+      else
+        yield
+      end
     end
   end
 end

--- a/lib/lookbook/preview_controller.rb
+++ b/lib/lookbook/preview_controller.rb
@@ -27,7 +27,7 @@ module Lookbook
     end
 
     def with_optional_annotations
-      if Lookbook.config.preview_disable_action_view_annotations
+      if ActionView::Base.respond_to?(:annotate_rendered_view_with_filenames) && Lookbook.config.preview_disable_action_view_annotations
         original_value = ActionView::Base.annotate_rendered_view_with_filenames
         ActionView::Base.annotate_rendered_view_with_filenames = false
 


### PR DESCRIPTION
Rails allows you to set a config option named `config.action_view.annotate_rendered_view_with_filenames` which will wrap rendered templates in HTML comments indicating the file system path of the file being rendered. This can be useful in dev environments to make it easier to track down where parts of the page are coming from. However it can create a bit of noise when viewing the HTML tab of a component in Lookbook. Below is an example of setting this value to `true` in the workbench app.

<img width="1244" alt="Screen Shot 2022-09-13 at 12 07 03 PM" src="https://user-images.githubusercontent.com/54561/189955511-32f1e8f5-5610-4756-be3f-19e65429555f.png">

This PR introduces a new Lookbook config setting to generate this source without these annotations in the event the setting is enabled. Setting `config.lookbook.disable_action_view_annotations = true` will generate the source without them.

<img width="1322" alt="Screen Shot 2022-09-13 at 12 16 39 PM" src="https://user-images.githubusercontent.com/54561/189955687-6ddb123f-a4cb-451b-8d51-0d4abec56a35.png">

I made this a configuration setting in the event there are folks who want to leave these annotations in place. I'm defaulting it to `false` because that matches the existing functionality so it feels less disruptive. I'm happy to change the default to `true` if you feel otherwise though.

The `action_view.annotate_rendered_view_with_filenames` config option was first added to Rails in 6.1.0. I'm not sure the best way to test this in versions prior to that to ensure it works or which versions we want to ensure Lookbook is compatible with.