### PR TITLE
Fix errors when VC monkey patch is disabled in older Rails versions

### DIFF
--- a/app/components/lookbook/base_component.rb
+++ b/app/components/lookbook/base_component.rb
@@ -12,11 +12,10 @@ module Lookbook
       merged_classes = class_names(attrs[:class], @html_attrs[:class])
       merged_attrs = @html_attrs.except(:class).deep_merge(attrs.except(:class))
 
-      render Lookbook::TagComponent.new(tag: tag,
-        name: component_name,
+      lookbook_tag tag, name: component_name,
         **merged_attrs,
         "x-data": prepare_alpine_data(merged_attrs[:"x-data"]),
-        class: merged_classes), &block
+        class: merged_classes, &block
     end
 
     def component_name

--- a/app/components/lookbook/button/component.html.erb
+++ b/app/components/lookbook/button/component.html.erb
@@ -10,7 +10,7 @@
   disabled: @disabled,
   "@keydown.esc.stop": "hideDropdown" do %>
   <span x-ref="icon">
-    <%= icon || render_component(:icon, name: @icon, size: icon_size, ":class": "{'animate-spin': _spinning}") %>
+    <%= icon || lookbook_render(:icon, name: @icon, size: icon_size, ":class": "{'animate-spin': _spinning}") %>
   </span>
   <% if @tooltip %>
     <label class="hidden" x-ref="tooltip"><%= @tooltip %></label>

--- a/app/components/lookbook/button_group/component.rb
+++ b/app/components/lookbook/button_group/component.rb
@@ -2,12 +2,11 @@ module Lookbook
   class ButtonGroup::Component < Lookbook::BaseComponent
     renders_many :buttons, ->(copy: nil, **attrs, &block) do
       attrs[:size] = @size
-      instance = if copy.present?
-        CopyButton::Component.new(target: copy, **attrs)
+      if copy.present?
+        lookbook_render :copy_button, target: copy, **attrs, &block
       else
-        Button::Component.new(**attrs)
+        lookbook_render :button, **attrs, &block
       end
-      render instance, &block
     end
 
     def initialize(size: :md, **html_attrs)

--- a/app/components/lookbook/copy_button/component.html.erb
+++ b/app/components/lookbook/copy_button/component.html.erb
@@ -1,4 +1,4 @@
-<%= render_component :button,
+<%= lookbook_render :button,
   name: "copy-button",
   **@button_attrs,
   "x-data": prepare_alpine_data,

--- a/app/components/lookbook/embed/component.html.erb
+++ b/app/components/lookbook/embed/component.html.erb
@@ -1,14 +1,14 @@
 <% if @target.present? %>
 <%= render_component_tag class: "not-prose border-b border-lookbook-divider rounded-sm overflow-hidden", "@navigation:start.window": "cleanup" do %>
 
-  <%= render_component :toolbar, class: "border border-b-0 border-lookbook-divider" do |toolbar| %>
+  <%= lookbook_render :toolbar, class: "border border-b-0 border-lookbook-divider" do |toolbar| %>
     <% toolbar.section padded: true do %>
       <h3>
         <%= @target.preview.label %> (<%= @target.label %>)
       </h3>
     <% end %>
     <% toolbar.section align: :right, divide: :left do %>
-      <%= render_component :button_group do |group| %>
+      <%= lookbook_render :button_group do |group| %>
         <% group.button icon: :eye,
           href: lookbook_inspect_path(@target.path, @params),
           tooltip: "View in Inspector" %>
@@ -27,7 +27,7 @@
     @viewport:resize-progress="resizeIframe"
     @viewport:resize-complete="resizeIframe"
     @tabs:change.window="resizeIframe"> 
-    <%= render_component :viewport,
+    <%= lookbook_render :viewport,
       src: lookbook_preview_path(@target.path, @params.merge(lookbook_embed: true)),
       alpine_data: "store",
       resize_height: false,

--- a/app/components/lookbook/header/component.html.erb
+++ b/app/components/lookbook/header/component.html.erb
@@ -1,5 +1,5 @@
 <%= render_component_tag :header do %>
-  <%= render_component :toolbar, class: "!bg-lookbook-header-bg !text-lookbook-header-text !border-lookbook-header-border" do |toolbar| %>
+  <%= lookbook_render :toolbar, class: "!bg-lookbook-header-bg !text-lookbook-header-text !border-lookbook-header-border" do |toolbar| %>
     <% toolbar.section padded: true do %>
       <% if branding.present? %>
         <a
@@ -11,7 +11,7 @@
     <% end %>
 
     <% toolbar.section padded: false, align: :right, class: "flex items-center" do %>
-      <%= render_component :button_group do |group| %>
+      <%= lookbook_render :button_group do |group| %>
         <% if @debug_menu %>
           <% group.button icon: :help_circle, class: "opacity-50 hover:opacity-100 transition !text-lookbook-header-text" do |button| %>
             <% button.dropdown do %>

--- a/app/components/lookbook/nav/component.rb
+++ b/app/components/lookbook/nav/component.rb
@@ -18,7 +18,7 @@ module Lookbook
 
     def items
       @collection.non_empty_items.map do |item|
-        render Lookbook::Nav::Item::Component.new item,
+        lookbook_render Lookbook::Nav::Item::Component.new item,
           nav_id: @id,
           depth: 1,
           **@item_args

--- a/app/components/lookbook/nav/item/component.html.erb
+++ b/app/components/lookbook/nav/item/component.html.erb
@@ -6,7 +6,7 @@
     "entity-type": item.type
   },
   cloak: true do %>
-  <%= render_tag href.present? ? :a : :div,
+  <%= lookbook_tag href.present? ? :a : :div,
     href: href,
     class: "flex items-center py-1 select-none cursor-pointer text-lookbook-nav-text hover:bg-lookbook-nav-item-hover",
     style: "padding-left: #{left_pad}px",

--- a/app/components/lookbook/nav/item/component.rb
+++ b/app/components/lookbook/nav/item/component.rb
@@ -45,7 +45,7 @@ module Lookbook
     def children
       @children ||= if collection? && !collapsed?
         item.non_empty_items.map do |item|
-          render Lookbook::Nav::Item::Component.new item,
+          lookbook_render Lookbook::Nav::Item::Component.new item,
             nav_id: @nav_id,
             depth: (@depth + 1),
             collapse_singles: @collapse_singles

--- a/app/components/lookbook/page_tabs/component.html.erb
+++ b/app/components/lookbook/page_tabs/component.html.erb
@@ -1,16 +1,16 @@
  <%= render_component_tag "x-data": "{ activeTab: null }" do %>
   <div class="flex w-full border-b border-lookbook-divider mb-6">
-    <%= render_component :tabs, theme: :page do |t| %>
+    <%= lookbook_render :tabs, theme: :page do |t| %>
       <% @tabs.each do |props| %>
         <%= t.tab **props %>
       <% end %>
     <% end %>
   </div>
-  <%= render_component :tab_panels do |t| %>
+  <%= lookbook_render :tab_panels do |t| %>
     <% @tabs.each do |props| %>
       <% t.panel name: props[:name] do %>
-        <%= render_component :prose, markdown: props[:markdown], class: "max-w-none flex-none" do %>
-          <%== props[:content] %>
+        <%= lookbook_render :prose, markdown: props[:markdown], class: "max-w-none flex-none" do %>
+          <%== props[:tab_content] %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/lookbook/page_tabs/component.rb
+++ b/app/components/lookbook/page_tabs/component.rb
@@ -2,7 +2,7 @@ module Lookbook
   class PageTabs::Component < Lookbook::BaseComponent
     renders_many :tabs, ->(**attrs, &block) do
       @tabs ||= []
-      attrs[:content] = capture(&block)
+      attrs[:tab_content] = capture(&block)
       attrs[:markdown] ||= @markdown
       @tabs << attrs
     end

--- a/app/components/lookbook/tabs/component.html.erb
+++ b/app/components/lookbook/tabs/component.html.erb
@@ -9,8 +9,8 @@
     <%= safe_join(tabs) %>
   </div>
   <div x-ref="dropdownTrigger" class="absolute" x-show="hasHiddenTabs" :style="{left: `${triggerLeft}px`}">
-    <%= render_component :button, icon: :chevrons_right, "x-show": "visibleTabsCount > 0" %>
-    <%= render_component :button, icon: :menu, class: "-ml-3", "x-show": "visibleTabsCount === 0" %>
+    <%= lookbook_render :button, icon: :chevrons_right, "x-show": "visibleTabsCount > 0" %>
+    <%= lookbook_render :button, icon: :menu, class: "-ml-3", "x-show": "visibleTabsCount === 0" %>
   </div>
   <div class="hidden">
     <div x-ref="tabsDropdown" data-cloak>

--- a/app/helpers/lookbook/page_helper.rb
+++ b/app/helpers/lookbook/page_helper.rb
@@ -22,7 +22,7 @@ module Lookbook
 
       embed_id = "#{url_for}/embed/#{example.lookup_path}".delete_prefix("/").tr("/", "-")
 
-      render_component :embed,
+      lookbook_render :embed,
         id: embed_id,
         example: example,
         params: params,

--- a/app/views/layouts/lookbook/application.html.erb
+++ b/app/views/layouts/lookbook/application.html.erb
@@ -1,6 +1,6 @@
 <% content_for :shell do %>
   <% if @previews.any? || @pages.any? %>
-    <%= render_component :split_layout,
+    <%= lookbook_render :split_layout,
       alpine_data: "$store.layout.main",
       ":class": "$store.layout.mobile && '!block'" do |layout| %>
 
@@ -13,13 +13,13 @@
         "@click.outside": "closeMobileSidebar",
         cloak: true do %>
 
-        <%= render_component :split_layout,
+        <%= lookbook_render :split_layout,
           alpine_data: "$store.layout.#{@pages.any? && @previews.any? ? "sidebar" : "singleSectionSidebar"}",
           style: "height: calc(100vh - 2.5rem);" do |layout| %>
 
           <% if @previews.any? %>
             <% layout.pane class: "overflow-hidden" do %>
-              <%= render_component :nav,
+              <%= lookbook_render :nav,
                 id: "previews-nav",
                 collection: @previews,
                 alpine_data: "$store.nav.previews",
@@ -36,7 +36,7 @@
 
           <% if @pages.any? %>
             <% layout.pane class: "overflow-hidden" do %>
-              <%= render_component :nav,
+              <%= lookbook_render :nav,
                 id: "pages-nav",
                 collection: @pages,
                 alpine_data: "$store.nav.pages" do |nav| %>

--- a/app/views/layouts/lookbook/page.html.erb
+++ b/app/views/layouts/lookbook/page.html.erb
@@ -12,14 +12,14 @@
           <div class="relative z-10 flex items-center">
           
           <% if @previous_page %>
-            <%= render_component :button,
+            <%= lookbook_render :button,
               size: :lg,
               icon: :chevron_left,
               tooltip: "Previous page",
               href: lookbook_page_path(@previous_page.lookup_path),
               class: "pr-0.5 bg-transparent" %>
           <% else %>
-            <%= render_component :button,
+            <%= lookbook_render :button,
               size: :lg,
               icon: :chevron_left,
               disabled: true,
@@ -27,14 +27,14 @@
           <% end %>
 
           <% if @next_page %>
-            <%= render_component :button,
+            <%= lookbook_render :button,
               size: :lg,
               icon: :chevron_right,
               tooltip: "Next page",
               href: lookbook_page_path(@next_page.lookup_path),
               class: "pl-0.5 bg-transparent" %>
           <% else %>
-            <%= render_component :button,
+            <%= lookbook_render :button,
               size: :lg,
               icon: :chevron_right,
               disabled: true,

--- a/app/views/layouts/lookbook/shell.html.erb
+++ b/app/views/layouts/lookbook/shell.html.erb
@@ -13,7 +13,7 @@
       </style>
     <% end %>
 
-    <%= render_component :header, id: "app-header", debug_menu: config.debug_menu do |header| %>
+    <%= lookbook_render :header, id: "app-header", debug_menu: config.debug_menu do |header| %>
       <% header.branding { config.project_name } %>
     <% end %>
 

--- a/app/views/lookbook/error.html.erb
+++ b/app/views/lookbook/error.html.erb
@@ -24,7 +24,7 @@ error = error.is_a?(Lookbook::Error) ? error : Lookbook::Error.new(error)
 
     <% if error.source_code %>
       <div class="mx-8 border border-red-200 max-w-screen-lg">
-        <%= render_component :code,
+        <%= lookbook_render :code,
           language: error.file_lang,
           highlight_lines: [error.source_code[:highlighted_line]],
           start_line: error.source_code[:start_line],

--- a/app/views/lookbook/pages/show.html.erb
+++ b/app/views/lookbook/pages/show.html.erb
@@ -6,12 +6,12 @@
       </header>
     <% end %>
 
-    <%= render_component :prose, id: "page-content", markdown: false, class: "max-w-none flex-none" do %>
+    <%= lookbook_render :prose, id: "page-content", markdown: false, class: "max-w-none flex-none" do %>
       <%= @page_content %>
     <% end %>
 
     <% if @page.sections.any? %>
-      <%= render_component :page_tabs, id: "page-tabbed-sections", markdown: false, class: "mt-6" do |page_tabs| %>
+      <%= lookbook_render :page_tabs, id: "page-tabbed-sections", markdown: false, class: "mt-6" do |page_tabs| %>
         <% @page.sections.each do |section| %>
           <% page_tabs.tab name: "page-section-#{section.name}", label: section.label do %>
             <%= page_controller.render_page(section) %>

--- a/app/views/lookbook/previews/panels/_content.html.erb
+++ b/app/views/lookbook/previews/panels/_content.html.erb
@@ -1,11 +1,11 @@
 <div class="p-4 bg-lookbook-prose-bg h-full">
   <% if panel.content.present? %>
-    <%= render_component :prose, markdown: true do %>
+    <%= lookbook_render :prose, markdown: true do %>
       <%== panel.content %>
     <% end %>
   <% else %>
     <% if Rails.env.development? %>
-      <%= render_component :prose do %>
+      <%= lookbook_render :prose do %>
         <em class='opacity-50'>No content has been defined for this panel.</em>
       <% end %>
     <% end %>

--- a/app/views/lookbook/previews/panels/_notes.html.erb
+++ b/app/views/lookbook/previews/panels/_notes.html.erb
@@ -6,13 +6,13 @@
         <h6 class="italic font-mono mb-4 opacity-40">
           # <%= item.label %>
         </h6>
-        <%= render_component :prose, content: item.notes %>
+        <%= lookbook_render :prose, content: item.notes %>
       </div>
     <% end %>
   </div>
 <% else %>
   <div class="px-4 py-6 bg-lookbook-prose-bg w-full h-full">
-    <%= render_component :prose do %>
+    <%= lookbook_render :prose do %>
       <%== items.any? ? items.first.notes : "<em class='opacity-50'>No notes provided.</em>" %>
     <% end %>
   </div>

--- a/app/views/lookbook/previews/panels/_output.html.erb
+++ b/app/views/lookbook/previews/panels/_output.html.erb
@@ -1,4 +1,4 @@
-<%= render_component :code, line_numbers: true, full_height: true do -%>
+<%= lookbook_render :code, line_numbers: true, full_height: true do -%>
   <% if examples.many? -%>
     <% examples.each do |example| -%><%== "<!-- #{example.label} -->\n#{beautify(example.output)}\n\n" -%><% end %>
   <%- else -%>

--- a/app/views/lookbook/previews/panels/_params.html.erb
+++ b/app/views/lookbook/previews/panels/_params.html.erb
@@ -1,12 +1,12 @@
 <% if preview.params.none? %>
   <div class="p-4 w-full h-full bg-lookbook-prose-bg">
-    <%= render_component :prose do %>
+    <%= lookbook_render :prose do %>
       <em class='opacity-50'>No params configured.</em>
     <% end %>
   </div>
 <% else %>
   <div class="py-3 h-full">
-    <%= render_component :params_editor do |editor| %>
+    <%= lookbook_render :params_editor do |editor| %>
       <% preview.params.each do |param| %>
         <% editor.field **param, value: params[param[:name]] %>
       <% end %>

--- a/app/views/lookbook/previews/panels/_preview.html.erb
+++ b/app/views/lookbook/previews/panels/_preview.html.erb
@@ -1,4 +1,4 @@
-<%= render_component :viewport,
+<%= lookbook_render :viewport,
   src: lookbook_preview_path(request.query_parameters.merge(lookbook_timestamp: Time.now)),
   alpine_data: "$store.inspector.main",
   class: "-inset-px relative",

--- a/app/views/lookbook/previews/panels/_source.html.erb
+++ b/app/views/lookbook/previews/panels/_source.html.erb
@@ -1,11 +1,11 @@
 <div class="h-full">
   <% if examples.many? %>
-    <%= render_component :code, language: examples.first.source_lang[:name], line_numbers: true, full_height: true do -%>
+    <%= lookbook_render :code, language: examples.first.source_lang[:name], line_numbers: true, full_height: true do -%>
 <%- examples.each.with_index(1) do |example, i| -%>
 <%== "#{sprintf example.source_lang[:comment], example.label}\n#{example.source}\n#{"\n" if i < examples.size}" %><% end %>
     <% end %>
   <% else %>
     <% example = examples.first %>
-    <%= render_component :code, language: example.source_lang[:name], line_numbers: true, full_height: true do %><%== example.source %><% end %>
+    <%= lookbook_render :code, language: example.source_lang[:name], line_numbers: true, full_height: true do %><%== example.source %><% end %>
   <% end %>
 </div>

--- a/app/views/lookbook/previews/show.html.erb
+++ b/app/views/lookbook/previews/show.html.erb
@@ -1,13 +1,13 @@
-<%= render_component :split_layout,
+<%= lookbook_render :split_layout,
   alpine_data: "$store.layout.inspector",
   ":class": "($store.inspector.drawer.hidden || #{@drawer_panels.none?}) && '!grid-rows-[1fr] !grid-cols-[1fr]'" do |layout| %>
 
   <%= layout.pane class: "flex flex-col h-full overflow-hidden",
     "x-effect": "forceOrientation = (layoutWidth < $store.inspector.minVerticalSplitWidth) ? 'horizontal' : null" do %>
   
-    <%= render_component :toolbar do |toolbar| %>
+    <%= lookbook_render :toolbar do |toolbar| %>
       <% toolbar.section ":class": "layoutResizing && 'overflow-hidden'" do %>
-        <%= render_component :tabs, alpine_data: "$store.inspector.main" do |tabs| %>
+        <%= lookbook_render :tabs, alpine_data: "$store.inspector.main" do |tabs| %>
           <%= @main_panels.each do |panel| %>
             <% tabs.tab name: panel.name,
               label: panel.label,
@@ -18,13 +18,13 @@
       <% end %>
 
       <% toolbar.section align: :right, padded: true, class: "flex-none min-w-[140px]", ":class": "{invisible: $store.inspector.main.activeTab !== 'preview'}" do %>
-        <%= render_component :dimensions_display,
+        <%= lookbook_render :dimensions_display,
           target: "[data-component=viewport] iframe",
           class: "ml-auto opacity-30 hover:opacity-100" %>
       <% end %>
 
       <% toolbar.section divide: :left, class: "flex-none relative z-10" do %>
-        <%= render_component :button_group do |group| %>
+        <%= lookbook_render :button_group do |group| %>
           <% if @pages.any? %>
             <% group.button icon: :code,
               tooltip: "Copy page embed code",
@@ -53,7 +53,7 @@
     <% end %>
 
     <div class="h-full relative overflow-auto">
-      <%= render_component :tab_panels, alpine_data: "$store.inspector.main" do |tabs| %>
+      <%= lookbook_render :tab_panels, alpine_data: "$store.inspector.main" do |tabs| %>
         <% @main_panels.each do |panel| %>
           <% tabs.panel id: panel.id, name: panel.name, class: panel.panel_classes do %>
             <%= render panel.partial, **@inspector_data, panel: panel, **panel.locals %>
@@ -66,9 +66,9 @@
   <%= layout.pane class: "flex flex-col h-full overflow-hidden bg-lookbook-drawer-bg",
     "x-show": "!$store.inspector.drawer.hidden && #{@drawer_panels.any?}" do %>
 
-    <%= render_component :toolbar do |toolbar| %>
+    <%= lookbook_render :toolbar do |toolbar| %>
       <% toolbar.section ":class": "layoutResizing && 'overflow-hidden'" do %>
-        <%= render_component :tabs, alpine_data: "$store.inspector.drawer" do |tabs| %>
+        <%= lookbook_render :tabs, alpine_data: "$store.inspector.drawer" do |tabs| %>
           <%= @drawer_panels.each do |panel| %>
             <% tabs.tab name: panel.name,
               label: panel.label,
@@ -79,7 +79,7 @@
       <% end %>
 
       <% toolbar.section align: :right,  class: "flex-none relative z-10" do %>
-        <%= render_component :button_group do |group| %>
+        <%= lookbook_render :button_group do |group| %>
           <%= @drawer_panels.select { |p| !p.disabled && p.copy }.each do |panel| %>
             <% group.button icon: :copy,
               tooltip: "Copy panel contents",
@@ -93,7 +93,7 @@
       <% end %>
 
       <% toolbar.section divide: :left, class: "flex-none relative z-10" do %>
-        <%= render_component :button_group do |group| %>
+        <%= lookbook_render :button_group do |group| %>
 
           <% group.button icon: :corner_up_right,
             tooltip: "Move drawer to right",
@@ -121,10 +121,10 @@
     <% end %> 
 
     <div class="h-full overflow-auto">
-      <%= render_component :tab_panels, alpine_data: "$store.inspector.drawer" do |tabs| %>
+      <%= lookbook_render :tab_panels, alpine_data: "$store.inspector.drawer" do |tabs| %>
         <% @drawer_panels.each do |panel| %>
           <% tabs.panel id: panel.id, name: panel.name, class: panel.panel_classes  do %>
-            <%= render_component :inspector_panel, **panel.slice(:id, :name, :system) do %>
+            <%= lookbook_render :inspector_panel, **panel.slice(:id, :name, :system) do %>
               <%= render panel.partial, **@inspector_data, panel: panel, **panel.locals %>
             <% end %>
           <% end %>


### PR DESCRIPTION
Fixes #156 which was caused by Lookbook relying on the `render` method to render its own components - however older Rails versions with the VC monkey patch disabled need to use the `render_component` method instead.