### PR TITLE
fix: Ensure key is a string for `start_with?`

### DIFF
--- a/lib/lookbook/theme.rb
+++ b/lib/lookbook/theme.rb
@@ -41,7 +41,7 @@ module Lookbook
       return @css unless @css.nil?
       @css ||= if @overrides.present?
         styles = [":root {"]
-        styles << @overrides.select { |key| !key.start_with?("favicon") }.map do |key, value|
+        styles << @overrides.reject { |key| key.to_s.start_with?("favicon") }.map do |key, value|
           "  --lookbook-#{key.to_s.underscore.tr("_", "-")}: #{value};"
         end
         styles.push "}"


### PR DESCRIPTION
In `lib/lookbook/theme.rb:44` it checks `key.start_with?("favicon")`. Unfortunately, `key` is a symbol and support for `start_with?` for symbols wasn't added until Ruby 2.7

Sorry to be constantly opening PR's to support older versions of Ruby but Lookbook has be super awesome for us and we'd love to keep using it! Hopefully after we update I can start contributing real features and not just patches ❤️ 

I also did a minor syntax change from `select` to `reject` for filtering since I think it's a little clearer to reject keys that start with "faviocon" rather than select keys that dont start with favicon.  But this might just be my preference so I can roll it back if you want.

Thanks for all you do!