### PR TITLE
Add config option to make rails logger optional

### DIFF
--- a/docs/src/_data/config_options.yml
+++ b/docs/src/_data/config_options.yml
@@ -15,6 +15,13 @@
     _Only applicable if no logger has been set in the parent application_, otherwise Lookbook
     will use that logger and the log level value that has been set on it.
 
+- name: log_use_rails_logger
+  group: debugging
+  type: Boolean
+  default: true
+  example: config.lookbook.log_use_rails_logger = true
+  description: Whether or not Lookbook should use the Rails logger when it is present.
+
 - name: debug_menu
   group: debugging
   type: Boolean

--- a/lib/lookbook/config.rb
+++ b/lib/lookbook/config.rb
@@ -10,6 +10,7 @@ module Lookbook
       @options.set({
         project_name: "Lookbook",
         log_level: 2,
+        log_use_rails_logger: true,
         auto_refresh: true,
 
         components_path: "app/components",

--- a/lib/lookbook/engine.rb
+++ b/lib/lookbook/engine.rb
@@ -28,7 +28,7 @@ module Lookbook
     end
 
     def logger
-      @logger ||= if Rails.logger.present?
+      @logger ||= if Rails.logger.present? && config.log_use_rails_logger
         Rails.logger
       else
         logger = Logger.new($stdout)


### PR DESCRIPTION
Our local development environment uses a verbose logging level and the Lookbook logs are adding quite a bit of extra stuff to them. I'm proposing a new configuration option that would let us tell Lookbook not to use the Rails logger even though we're running inside a Rails app. This will give us a bit more control over our logs.

I've defaulted the value to `true` so it should match the existing behavior.